### PR TITLE
fixed wrong digest uri

### DIFF
--- a/Core/Sasl/Mechanisms/SaslDigestMd5.cs
+++ b/Core/Sasl/Mechanisms/SaslDigestMd5.cs
@@ -151,7 +151,7 @@ namespace S22.Xmpp.Core.Sasl.Mechanisms {
 			// Parse the challenge-string and construct the "response-value" from it.
 			string decoded = Encoding.ASCII.GetString(challenge);
 			NameValueCollection fields = ParseDigestChallenge(decoded);
-			string digestUri = "imap/" + fields["realm"];
+			string digestUri = "xmpp/" + fields["realm"];
 			string responseValue = ComputeDigestResponseValue(fields, Cnonce, digestUri,
 				Username, Password);
 


### PR DESCRIPTION
wrong digest uri prevented ssl connection to openfire servers. prosody servers seem unaffected.
