### PR TITLE
After downloading this repo and opening the files manually and steppi…

### DIFF
--- a/Im/XmppIm.cs
+++ b/Im/XmppIm.cs
@@ -1483,7 +1483,7 @@ namespace S22.Xmpp.Im {
 
 			// Only raise the Message event, if the message stanza actually contains
 			// a body.
-			if(message.Data["body"] != null)
+			if (message.Data["body"] != null || message.Data["event"] != null)
 				Message.Raise(this, new MessageEventArgs(message.From, message));
 		}
 


### PR DESCRIPTION
 #20 …Fixed this issue for me. This saved me having to spend a few thousand dollars with Matrix. From debugging @smiley22 awesome work, it seems line 1486 of Xmpplm.cs is only checking to see if the XMLNODE has a BODY tag, but messages from Cisco do not have a BODY, they have an EVENT tag.

See Example XML Payload below. 

<message from='ekavanagh@********' to='ekavanagh@*******/5a7qs9ypxj' id='5a7qs9ypxj'>
<event xmlns='http://jabber.org/protocol/pubsub#event'>
<items node='/finesse/api/User/radlam'>
<item id='4b7e23ea-f951-421f-88d0-0bb4c44599d61178215'>
<notification xmlns='http://jabber.org/protocol/pubsub'><Update>
<data>
<user>
<dialogs>/finesse/api/User/radlam/Dialogs</dialogs>
<extension>4165</extension>
<firstName>Rose</firstName>
<lastName>Adlam</lastName>
<loginId>radlam</loginId>
<loginName>radlam</loginName>
<mediaType>1</mediaType>
<pendingState></pendingState>
<reasonCode>
<category>NOT_READY</category>
<code>861</code>
<forAll>true</forAll>
<id>63</id>
<label>Fun Activities</label>
<systemCode>false</systemCode>
<uri>/finesse/api/ReasonCode/63</uri>
</reasonCode>
<reasonCodeId>63</reasonCodeId>
<roles>
<role>Agent</role>
<role>Supervisor</role>
</roles>
<settings>
<wrapUpOnIncoming></wrapUpOnIncoming>
</settings>
<state>NOT_READY</state>
<stateChangeTime>2021-04-20T02:14:46.303Z</stateChangeTime>
<teamId>29</teamId>
<teamName>Tier 2</teamName>
<teams>
<Team>
<id>29</id>
<name>Tier 2</name>
<uri>/finesse/api/Team/29</uri>
</Team>
<Team>
<id>26</id>
<name>Tier 1</name>
<uri>/finesse/api/Team/26</uri>
</Team>
</teams>
<uri>/finesse/api/User/radlam</uri>
</user>
</data>
<event>PUT</event>
<requestId>3d639227-a7b6-445e-b5cf-abfdd14976c6</requestId>
<source>/finesse/api/User/radlam</source>
</Update></notification>
</item>
</items>
</event>
</message>
